### PR TITLE
Update GitHub Actions to prevent unexpected running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - "*"
+      - "main"
     tags:
       - "v*"
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: test
     steps:
       - name: Checkout


### PR DESCRIPTION
- Change trigger branch from all to main.
- Make 'build-docs' job to run only on the main branch.