### PR TITLE
Add fill parameter to SimpleGridCell

### DIFF
--- a/grid/src/androidInstrumentedTest/kotlin/io/woong/compose/grid/GridTest.kt
+++ b/grid/src/androidInstrumentedTest/kotlin/io/woong/compose/grid/GridTest.kt
@@ -168,6 +168,68 @@ class GridTest {
     }
 
     @Test
+    fun testHorizontalGrid_oneItem_withFixed_fillFalse() {
+        val itemTag = "1"
+        val itemSize = 10.dp
+        val gridHeight = 30.dp
+
+        composeRule.setContent {
+            HorizontalGrid(
+                rows = SimpleGridCells.Fixed(1, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .height(gridHeight),
+                content = {
+                    Box(
+                        modifier = Modifier
+                            .testTag(itemTag)
+                            .size(itemSize)
+                    )
+                }
+            )
+        }
+
+        composeRule
+            .onNode(hasTestTag(itemTag))
+            .assertSizeIsEqualTo(expectedWidth = itemSize, expectedHeight = itemSize)
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertSizeIsEqualTo(expectedWidth = itemSize, expectedHeight = gridHeight)
+    }
+
+    @Test
+    fun testVerticalGrid_oneItem_withFixed_fillFalse() {
+        val itemTag = "1"
+        val itemSize = 10.dp
+        val gridWidth = 30.dp
+
+        composeRule.setContent {
+            VerticalGrid(
+                columns = SimpleGridCells.Fixed(1, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .width(gridWidth),
+                content = {
+                    Box(
+                        modifier = Modifier
+                            .testTag(itemTag)
+                            .size(itemSize)
+                    )
+                }
+            )
+        }
+
+        composeRule
+            .onNode(hasTestTag(itemTag))
+            .assertSizeIsEqualTo(expectedWidth = itemSize, expectedHeight = itemSize)
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertSizeIsEqualTo(expectedWidth = gridWidth, expectedHeight = itemSize)
+    }
+
+    @Test
     fun testHorizontalGrid_oneItem_withFixed_multipleCount() {
         val itemTag = "1"
         val itemSize = 10.dp
@@ -227,6 +289,74 @@ class GridTest {
         composeRule
             .onNode(hasTestTag(itemTag))
             .assertWidthIsEqualTo(gridWidth / columnCount)
+            .assertHeightIsEqualTo(itemSize)
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(gridWidth)
+            .assertHeightIsEqualTo(itemSize)
+    }
+
+    @Test
+    fun testHorizontalGrid_oneItem_withFixed_multipleCount_fillFalse() {
+        val itemTag = "1"
+        val itemSize = 10.dp
+        val gridHeight = 40.dp
+        val rowCount = 3
+
+        composeRule.setContent {
+            HorizontalGrid(
+                rows = SimpleGridCells.Fixed(rowCount, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .height(gridHeight),
+                content = {
+                    Box(
+                        modifier = Modifier
+                            .testTag(itemTag)
+                            .size(itemSize)
+                    )
+                }
+            )
+        }
+
+        composeRule
+            .onNode(hasTestTag(itemTag))
+            .assertWidthIsEqualTo(itemSize)
+            .assertHeightIsEqualTo(itemSize)
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(itemSize)
+            .assertHeightIsEqualTo(gridHeight)
+    }
+
+    @Test
+    fun testVerticalGrid_oneItem_withFixed_multipleCount_fillFalse() {
+        val itemTag = "1"
+        val itemSize = 10.dp
+        val gridWidth = 40.dp
+        val columnCount = 3
+
+        composeRule.setContent {
+            VerticalGrid(
+                columns = SimpleGridCells.Fixed(columnCount, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .width(gridWidth),
+                content = {
+                    Box(
+                        modifier = Modifier
+                            .testTag(itemTag)
+                            .size(itemSize)
+                    )
+                }
+            )
+        }
+
+        composeRule
+            .onNode(hasTestTag(itemTag))
+            .assertWidthIsEqualTo(itemSize)
             .assertHeightIsEqualTo(itemSize)
 
         composeRule
@@ -299,6 +429,70 @@ class GridTest {
         composeRule
             .onNode(hasTestTag(itemTag))
             .assertSizeIsEqualTo(expectedWidth = expectedItemWidth, expectedHeight = itemSize)
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertSizeIsEqualTo(expectedWidth = gridWidth, expectedHeight = itemSize)
+    }
+
+    @Test
+    fun testHorizontalGrid_oneItem_withAdaptive_fillFalse() {
+        val itemTag = "1"
+        val itemSize = 10.dp
+        val minHeight = 8.dp
+        val gridHeight = 30.dp
+
+        composeRule.setContent {
+            HorizontalGrid(
+                rows = SimpleGridCells.Adaptive(minHeight, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .height(gridHeight),
+                content = {
+                    Box(
+                        modifier = Modifier
+                            .testTag(itemTag)
+                            .size(itemSize)
+                    )
+                }
+            )
+        }
+
+        composeRule
+            .onNode(hasTestTag(itemTag))
+            .assertSizeIsEqualTo(expectedWidth = itemSize, expectedHeight = itemSize)
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertSizeIsEqualTo(expectedWidth = itemSize, expectedHeight = gridHeight)
+    }
+
+    @Test
+    fun testVerticalGrid_oneItem_withAdaptive_fillFalse() {
+        val itemTag = "1"
+        val itemSize = 10.dp
+        val minWidth = 8.dp
+        val gridWidth = 30.dp
+
+        composeRule.setContent {
+            VerticalGrid(
+                columns = SimpleGridCells.Adaptive(minWidth, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .width(gridWidth),
+                content = {
+                    Box(
+                        modifier = Modifier
+                            .testTag(itemTag)
+                            .size(itemSize)
+                    )
+                }
+            )
+        }
+
+        composeRule
+            .onNode(hasTestTag(itemTag))
+            .assertSizeIsEqualTo(expectedWidth = itemSize, expectedHeight = itemSize)
 
         composeRule
             .onNode(hasTestTag(gridTag))
@@ -384,6 +578,82 @@ class GridTest {
     }
 
     @Test
+    fun testHorizontalGrid_oneLine_withFixed_fillFalse() {
+        val rowCount = 3
+        val gridHeight = 45.dp
+        val itemSize = 10.dp
+
+        composeRule.setContent {
+            HorizontalGrid(
+                rows = SimpleGridCells.Fixed(rowCount, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .height(gridHeight),
+                content = {
+                    for (i in 0 until rowCount) {
+                        Box(
+                            modifier = Modifier
+                                .testTag(i.toString())
+                                .size(itemSize)
+                        )
+                    }
+                }
+            )
+        }
+
+        val expectedItemHeight = gridHeight / rowCount
+        for (i in 0 until rowCount) {
+            composeRule
+                .onNode(hasTestTag(i.toString()))
+                .assertSizeIsEqualTo(itemSize)
+                .assertTopPositionInRootIsEqualTo(expectedItemHeight * i)
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(itemSize)
+            .assertHeightIsEqualTo(gridHeight)
+    }
+
+    @Test
+    fun testVerticalGrid_oneLine_withFixed_fillFalse() {
+        val columnCount = 3
+        val gridWidth = 45.dp
+        val itemSize = 10.dp
+
+        composeRule.setContent {
+            VerticalGrid(
+                columns = SimpleGridCells.Fixed(columnCount, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .width(gridWidth),
+                content = {
+                    for (i in 0 until columnCount) {
+                        Box(
+                            modifier = Modifier
+                                .testTag(i.toString())
+                                .size(itemSize)
+                        )
+                    }
+                }
+            )
+        }
+
+        val expectedItemWidth = gridWidth / columnCount
+        for (i in 0 until columnCount) {
+            composeRule
+                .onNode(hasTestTag(i.toString()))
+                .assertSizeIsEqualTo(itemSize)
+                .assertLeftPositionInRootIsEqualTo(expectedItemWidth * i)
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(gridWidth)
+            .assertHeightIsEqualTo(itemSize)
+    }
+
+    @Test
     fun testHorizontalGrid_oneLine_withAdaptive() {
         val gridHeight = 30.dp
         val minHeight = 8.dp
@@ -454,6 +724,84 @@ class GridTest {
                 .onNode(hasTestTag(i.toString()))
                 .assertWidthIsEqualTo(expectedItemWidth)
                 .assertHeightIsEqualTo(itemSize)
+                .assertLeftPositionInRootIsEqualTo(expectedItemWidth * i)
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(gridWidth)
+            .assertHeightIsEqualTo(itemSize)
+    }
+
+    @Test
+    fun testHorizontalGrid_oneLine_withAdaptive_fillFalse() {
+        val gridHeight = 30.dp
+        val minHeight = 8.dp
+        val itemSize = 5.dp
+        val rowCount = expectAdaptiveGridCrossAxisCount(gridHeight, minHeight)
+
+        composeRule.setContent {
+            HorizontalGrid(
+                rows = SimpleGridCells.Adaptive(minHeight, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .height(gridHeight),
+                content = {
+                    for (i in 0 until rowCount) {
+                        Box(
+                            modifier = Modifier
+                                .testTag(i.toString())
+                                .size(itemSize)
+                        )
+                    }
+                }
+            )
+        }
+
+        val expectedItemHeight = gridHeight / rowCount
+        for (i in 0 until rowCount) {
+            composeRule
+                .onNode(hasTestTag(i.toString()))
+                .assertSizeIsEqualTo(itemSize)
+                .assertTopPositionInRootIsEqualTo(expectedItemHeight * i)
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(itemSize)
+            .assertHeightIsEqualTo(gridHeight)
+    }
+
+    @Test
+    fun testVerticalGrid_oneLine_withAdaptive_fillFalse() {
+        val gridWidth = 30.dp
+        val minWidth = 8.dp
+        val itemSize = 5.dp
+        val columnCount = expectAdaptiveGridCrossAxisCount(gridWidth, minWidth)
+
+        composeRule.setContent {
+            VerticalGrid(
+                columns = SimpleGridCells.Adaptive(minWidth, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .width(gridWidth),
+                content = {
+                    for (i in 0 until columnCount) {
+                        Box(
+                            modifier = Modifier
+                                .testTag(i.toString())
+                                .size(itemSize)
+                        )
+                    }
+                }
+            )
+        }
+
+        val expectedItemWidth = gridWidth / columnCount
+        for (i in 0 until columnCount) {
+            composeRule
+                .onNode(hasTestTag(i.toString()))
+                .assertSizeIsEqualTo(itemSize)
                 .assertLeftPositionInRootIsEqualTo(expectedItemWidth * i)
         }
 
@@ -556,6 +904,94 @@ class GridTest {
     }
 
     @Test
+    fun testHorizontalGrid_breakDownToNextLine_withFixed_fillFalse() {
+        val rowCount = 3
+        val gridHeight = 45.dp
+        val itemCount = rowCount + 1
+        val itemSize = 10.dp
+
+        composeRule.setContent {
+            HorizontalGrid(
+                rows = SimpleGridCells.Fixed(rowCount, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .height(gridHeight)
+            ) {
+                for (i in 0 until itemCount) {
+                    Box(
+                        modifier = Modifier
+                            .testTag(i.toString())
+                            .size(itemSize)
+                    )
+                }
+            }
+        }
+
+        for (i in 0 until itemCount) {
+            if (i < rowCount) {
+                composeRule
+                    .onNode(hasTestTag(i.toString()))
+                    .assertSizeIsEqualTo(itemSize)
+                    .assertTopPositionInRootIsEqualTo((gridHeight / rowCount) * i)
+            } else {
+                composeRule
+                    .onNode(hasTestTag(i.toString()))
+                    .assertSizeIsEqualTo(itemSize)
+                    .assertLeftPositionInRootIsEqualTo(itemSize)
+            }
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(itemSize * 2)
+            .assertHeightIsEqualTo(gridHeight)
+    }
+
+    @Test
+    fun testVerticalGrid_breakDownToNextLine_withFixed_fillFalse() {
+        val columnCount = 3
+        val gridWidth = 45.dp
+        val itemCount = columnCount + 1
+        val itemSize = 10.dp
+
+        composeRule.setContent {
+            VerticalGrid(
+                columns = SimpleGridCells.Fixed(columnCount, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .width(gridWidth)
+            ) {
+                for (i in 0 until itemCount) {
+                    Box(
+                        modifier = Modifier
+                            .testTag(i.toString())
+                            .size(itemSize)
+                    )
+                }
+            }
+        }
+
+        for (i in 0 until itemCount) {
+            if (i < columnCount) {
+                composeRule
+                    .onNode(hasTestTag(i.toString()))
+                    .assertSizeIsEqualTo(itemSize)
+                    .assertLeftPositionInRootIsEqualTo((gridWidth / columnCount) * i)
+            } else {
+                composeRule
+                    .onNode(hasTestTag(i.toString()))
+                    .assertSizeIsEqualTo(itemSize)
+                    .assertTopPositionInRootIsEqualTo(itemSize)
+            }
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(gridWidth)
+            .assertHeightIsEqualTo(itemSize * 2)
+    }
+
+    @Test
     fun testHorizontalGrid_breakDownToNextLine_withAdaptive() {
         val gridHeight = 30.dp
         val minHeight = 8.dp
@@ -641,6 +1077,98 @@ class GridTest {
                     .onNode(hasTestTag(i.toString()))
                     .assertWidthIsEqualTo(expectedItemWidth)
                     .assertHeightIsEqualTo(itemSize)
+                    .assertTopPositionInRootIsEqualTo(itemSize)
+            }
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(gridWidth)
+            .assertHeightIsEqualTo(itemSize * 2)
+    }
+
+    @Test
+    fun testHorizontalGrid_breakDownToNextLine_withAdaptive_fillFalse() {
+        val gridHeight = 30.dp
+        val minHeight = 8.dp
+        val itemSize = 5.dp
+        val rowCount = expectAdaptiveGridCrossAxisCount(gridHeight, minHeight)
+        val itemCount = rowCount + 1
+
+        composeRule.setContent {
+            HorizontalGrid(
+                rows = SimpleGridCells.Adaptive(minHeight, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .height(gridHeight)
+            ) {
+                for (i in 0 until itemCount) {
+                    Box(
+                        modifier = Modifier
+                            .testTag(i.toString())
+                            .size(itemSize)
+                    )
+                }
+            }
+        }
+
+        val expectedItemHeight = gridHeight / rowCount
+        for (i in 0 until itemCount) {
+            if (i < rowCount) {
+                composeRule
+                    .onNode(hasTestTag(i.toString()))
+                    .assertSizeIsEqualTo(itemSize)
+                    .assertTopPositionInRootIsEqualTo(expectedItemHeight * i)
+            } else {
+                composeRule
+                    .onNode(hasTestTag(i.toString()))
+                    .assertSizeIsEqualTo(itemSize)
+                    .assertLeftPositionInRootIsEqualTo(itemSize)
+            }
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(itemSize * 2)
+            .assertHeightIsEqualTo(gridHeight)
+    }
+
+    @Test
+    fun testVerticalGrid_breakDownToNextLine_withAdaptive_fillFalse() {
+        val gridWidth = 30.dp
+        val minWidth = 8.dp
+        val itemSize = 5.dp
+        val columnCount = expectAdaptiveGridCrossAxisCount(gridWidth, minWidth)
+        val itemCount = columnCount + 1
+
+        composeRule.setContent {
+            VerticalGrid(
+                columns = SimpleGridCells.Fixed(columnCount, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .width(gridWidth)
+            ) {
+                for (i in 0 until itemCount) {
+                    Box(
+                        modifier = Modifier
+                            .testTag(i.toString())
+                            .size(itemSize)
+                    )
+                }
+            }
+        }
+
+        val expectedItemWidth = gridWidth / columnCount
+        for (i in 0 until itemCount) {
+            if (i < columnCount) {
+                composeRule
+                    .onNode(hasTestTag(i.toString()))
+                    .assertSizeIsEqualTo(itemSize)
+                    .assertLeftPositionInRootIsEqualTo(expectedItemWidth * i)
+            } else {
+                composeRule
+                    .onNode(hasTestTag(i.toString()))
+                    .assertSizeIsEqualTo(itemSize)
                     .assertTopPositionInRootIsEqualTo(itemSize)
             }
         }
@@ -762,6 +1290,122 @@ class GridTest {
                         .onNode(hasTestTag(i.toString()))
                         .assertWidthIsEqualTo(gridWidth / columnCount)
                         .assertHeightIsEqualTo(itemSize)
+                        .assertTopPositionInRootIsEqualTo(itemSize * 2)
+                }
+            }
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(gridWidth)
+            .assertHeightIsEqualTo(itemSize * 3)
+    }
+
+    @Test
+    fun testHorizontalGrid_breakDownMultipleTimes_withFixed_fillFalse() {
+        val rowCount = 3
+        val gridHeight = 45.dp
+        val itemCount = rowCount * 2 + 1
+        val itemSize = 10.dp
+
+        composeRule.setContent {
+            HorizontalGrid(
+                rows = SimpleGridCells.Fixed(rowCount, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .height(gridHeight)
+            ) {
+                for (i in 0 until itemCount) {
+                    Box(
+                        modifier = Modifier
+                            .testTag(i.toString())
+                            .size(itemSize)
+                    )
+                }
+            }
+        }
+
+        for (i in 0 until itemCount) {
+            when {
+                i < rowCount -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertTopPositionInRootIsEqualTo((gridHeight / rowCount) * i)
+                }
+
+                i < rowCount * 2 -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertPositionInRootIsEqualTo(
+                            expectedLeft = itemSize,
+                            expectedTop = (gridHeight / rowCount) * (i - rowCount)
+                        )
+                }
+
+                else -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertLeftPositionInRootIsEqualTo(itemSize * 2)
+                }
+            }
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(itemSize * 3)
+            .assertHeightIsEqualTo(gridHeight)
+    }
+
+    @Test
+    fun testVerticalGrid_breakDownMultipleTimes_withFixed_fillFalse() {
+        val columnCount = 3
+        val gridWidth = 45.dp
+        val itemCount = columnCount * 2 + 1
+        val itemSize = 10.dp
+
+        composeRule.setContent {
+            VerticalGrid(
+                columns = SimpleGridCells.Fixed(columnCount, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .width(gridWidth)
+            ) {
+                for (i in 0 until itemCount) {
+                    Box(
+                        modifier = Modifier
+                            .testTag(i.toString())
+                            .size(itemSize)
+                    )
+                }
+            }
+        }
+
+        for (i in 0 until itemCount) {
+            when {
+                i < columnCount -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertLeftPositionInRootIsEqualTo((gridWidth / columnCount) * i)
+                }
+
+                i < columnCount * 2 -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertPositionInRootIsEqualTo(
+                            expectedLeft = (gridWidth / columnCount) * (i - columnCount),
+                            expectedTop = itemSize
+                        )
+                }
+
+                else -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
                         .assertTopPositionInRootIsEqualTo(itemSize * 2)
                 }
             }
@@ -900,6 +1544,126 @@ class GridTest {
     }
 
     @Test
+    fun testHorizontalGrid_breakDownMultipleTimes_withAdaptive_fillFalse() {
+        val gridHeight = 30.dp
+        val minHeight = 8.dp
+        val itemSize = 5.dp
+        val rowCount = expectAdaptiveGridCrossAxisCount(gridHeight, minHeight)
+        val itemCount = rowCount * 2 + 1
+
+        composeRule.setContent {
+            HorizontalGrid(
+                rows = SimpleGridCells.Adaptive(minHeight, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .height(gridHeight)
+            ) {
+                for (i in 0 until itemCount) {
+                    Box(
+                        modifier = Modifier
+                            .testTag(i.toString())
+                            .size(itemSize)
+                    )
+                }
+            }
+        }
+
+        val expectedItemHeight = gridHeight / rowCount
+        for (i in 0 until itemCount) {
+            when {
+                i < rowCount -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertTopPositionInRootIsEqualTo(expectedItemHeight * i)
+                }
+
+                i < rowCount * 2 -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertPositionInRootIsEqualTo(
+                            expectedLeft = itemSize,
+                            expectedTop = expectedItemHeight * (i - rowCount)
+                        )
+                }
+
+                else -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertLeftPositionInRootIsEqualTo(itemSize * 2)
+                }
+            }
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(itemSize * 3)
+            .assertHeightIsEqualTo(gridHeight)
+    }
+
+    @Test
+    fun testVerticalGrid_breakDownMultipleTimes_withAdaptive_fillFalse() {
+        val gridWidth = 30.dp
+        val minWidth = 8.dp
+        val itemSize = 5.dp
+        val columnCount = expectAdaptiveGridCrossAxisCount(gridWidth, minWidth)
+        val itemCount = columnCount * 2 + 1
+
+        composeRule.setContent {
+            VerticalGrid(
+                columns = SimpleGridCells.Adaptive(minWidth, fill = false),
+                modifier = Modifier
+                    .testTag(gridTag)
+                    .width(gridWidth)
+            ) {
+                for (i in 0 until itemCount) {
+                    Box(
+                        modifier = Modifier
+                            .testTag(i.toString())
+                            .size(itemSize)
+                    )
+                }
+            }
+        }
+
+        val expectedItemWidth = gridWidth / columnCount
+        for (i in 0 until itemCount) {
+            when {
+                i < columnCount -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertLeftPositionInRootIsEqualTo(expectedItemWidth * i)
+                }
+
+                i < columnCount * 2 -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertPositionInRootIsEqualTo(
+                            expectedLeft = expectedItemWidth * (i - columnCount),
+                            expectedTop = itemSize
+                        )
+                }
+
+                else -> {
+                    composeRule
+                        .onNode(hasTestTag(i.toString()))
+                        .assertSizeIsEqualTo(itemSize)
+                        .assertTopPositionInRootIsEqualTo(itemSize * 2)
+                }
+            }
+        }
+
+        composeRule
+            .onNode(hasTestTag(gridTag))
+            .assertWidthIsEqualTo(gridWidth)
+            .assertHeightIsEqualTo(itemSize * 3)
+    }
+
+    @Test
     fun testHorizontalGrid_notEnoughLayoutSize_withFixed() {
         val rowCount = 2
         val gridSize = 30.dp
@@ -1004,7 +1768,6 @@ class GridTest {
             .onNode(hasTestTag("3"))
             .assertIsNotDisplayed()
     }
-
 
     @Test
     fun testHorizontalGrid_notEnoughLayoutSize_withAdaptive() {

--- a/grid/src/commonMain/kotlin/io/woong/compose/grid/Grid.kt
+++ b/grid/src/commonMain/kotlin/io/woong/compose/grid/Grid.kt
@@ -48,6 +48,7 @@ inline fun HorizontalGrid(
     )
     val measurePolicy = rememberHorizontalGridMeasurePolicy(
         calculateRowCellHeightConstraints = calculateRowCellHeightsFunction,
+        fillCellHeight = remember(rows) { rows.fillCellSize() },
         horizontalArrangement = horizontalArrangement,
         verticalArrangement = verticalArrangement,
     )
@@ -81,6 +82,7 @@ inline fun VerticalGrid(
     )
     val measurePolicy = rememberVerticalGridMeasurePolicy(
         calculateColumnCellWidthConstraints = calculateColumnCellWidthsFunction,
+        fillCellWidth = remember(columns) { columns.fillCellSize() },
         horizontalArrangement = horizontalArrangement,
         verticalArrangement = verticalArrangement,
     )
@@ -143,13 +145,20 @@ internal fun rememberColumnCellWidthConstraints(
 @Composable
 internal fun rememberHorizontalGridMeasurePolicy(
     calculateRowCellHeightConstraints: Density.(Constraints) -> List<Int>,
+    fillCellHeight: Boolean,
     horizontalArrangement: Arrangement.Horizontal,
     verticalArrangement: Arrangement.Vertical,
 ): MeasurePolicy {
-    return remember(calculateRowCellHeightConstraints, horizontalArrangement, verticalArrangement) {
+    return remember(
+        calculateRowCellHeightConstraints,
+        fillCellHeight,
+        horizontalArrangement,
+        verticalArrangement
+    ) {
         gridMeasurePolicy(
             orientation = LayoutOrientation.Horizontal,
             calculateCrossAxisCellConstraints = calculateRowCellHeightConstraints,
+            fillCellSize = fillCellHeight,
             mainAxisArrangement = { totalSize, sizes, layoutDirection, density, outPosition ->
                 with(horizontalArrangement) {
                     density.arrange(totalSize, sizes, layoutDirection, outPosition)
@@ -170,13 +179,20 @@ internal fun rememberHorizontalGridMeasurePolicy(
 @Composable
 internal fun rememberVerticalGridMeasurePolicy(
     calculateColumnCellWidthConstraints: Density.(Constraints) -> List<Int>,
+    fillCellWidth: Boolean,
     horizontalArrangement: Arrangement.Horizontal,
     verticalArrangement: Arrangement.Vertical,
 ): MeasurePolicy {
-    return remember(calculateColumnCellWidthConstraints, horizontalArrangement, verticalArrangement) {
+    return remember(
+        calculateColumnCellWidthConstraints,
+        fillCellWidth,
+        horizontalArrangement,
+        verticalArrangement
+    ) {
         gridMeasurePolicy(
             orientation = LayoutOrientation.Vertical,
             calculateCrossAxisCellConstraints = calculateColumnCellWidthConstraints,
+            fillCellSize = fillCellWidth,
             mainAxisArrangement = { totalSize, sizes, _, density, outPosition ->
                 with(verticalArrangement) {
                     density.arrange(totalSize, sizes, outPosition)

--- a/grid/src/commonMain/kotlin/io/woong/compose/grid/MeasureHelper.kt
+++ b/grid/src/commonMain/kotlin/io/woong/compose/grid/MeasureHelper.kt
@@ -49,6 +49,7 @@ internal class GridMeasureHelper(
     val measurables: List<Measurable>,
     val placeables: Array<Placeable?>,
     val crossAxisCellConstraintsList: List<Int>,
+    val fillCellSize: Boolean,
     val crossAxisCount: Int,
     val mainAxisArrangement: (Int, IntArray, LayoutDirection, Density, IntArray) -> Unit,
     val mainAxisSpacing: Dp,
@@ -100,7 +101,7 @@ internal class GridMeasureHelper(
                             } else {
                                 mainAxisMaxLayoutSize - mainAxisPlacedSpace
                             },
-                            crossAxisMinSize = crossAxisCellConstraints,
+                            crossAxisMinSize = if (fillCellSize) crossAxisCellConstraints else 0,
                             crossAxisMaxSize = crossAxisCellConstraints,
                         ).toConstraints(orientation)
                     )

--- a/grid/src/commonMain/kotlin/io/woong/compose/grid/MeasurePolicy.kt
+++ b/grid/src/commonMain/kotlin/io/woong/compose/grid/MeasurePolicy.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.LayoutDirection
 internal fun gridMeasurePolicy(
     orientation: LayoutOrientation,
     calculateCrossAxisCellConstraints: Density.(Constraints) -> List<Int>,
+    fillCellSize: Boolean,
     mainAxisArrangement: (Int, IntArray, LayoutDirection, Density, IntArray) -> Unit,
     mainAxisSpacing: Dp,
     crossAxisArrangement: (Int, IntArray, LayoutDirection, Density, IntArray) -> Unit,
@@ -49,6 +50,7 @@ internal fun gridMeasurePolicy(
                 measurables = measurables,
                 placeables = placeables,
                 crossAxisCellConstraintsList = crossAxisCellConstraintsList,
+                fillCellSize = fillCellSize,
                 crossAxisCount = crossAxisCellCount,
                 mainAxisArrangement = mainAxisArrangement,
                 mainAxisSpacing = mainAxisSpacing,

--- a/grid/src/commonMain/kotlin/io/woong/compose/grid/SimpleGridCells.kt
+++ b/grid/src/commonMain/kotlin/io/woong/compose/grid/SimpleGridCells.kt
@@ -39,6 +39,8 @@ interface SimpleGridCells {
      */
     fun Density.calculateCrossAxisCellSizes(availableSize: Int, spacing: Int): List<Int>
 
+    fun fillCellSize(): Boolean
+
     /**
      * Make grid to have fixed number of rows or columns.
      *
@@ -46,8 +48,12 @@ interface SimpleGridCells {
      * 3 columns and each cell have 30dp width.
      *
      * @param count The number of rows or columns.
+     * @param fill When `true`, item composable fill cell's width or height.
      */
-    class Fixed(private val count: Int) : SimpleGridCells {
+    class Fixed(
+        private val count: Int,
+        private val fill: Boolean = true
+    ) : SimpleGridCells {
         init {
             if (count <= 0) {
                 throw IllegalArgumentException("Fixed count must be a positive value, but $count")
@@ -67,14 +73,22 @@ interface SimpleGridCells {
             }
         }
 
+        override fun fillCellSize(): Boolean {
+            return fill
+        }
+
         override fun equals(other: Any?): Boolean {
             if (other !is Fixed) return false
             if (this.count != other.count) return false
+            if (this.fill != other.fill) return false
             return true
         }
 
         override fun hashCode(): Int {
-            return count.hashCode()
+            var hash = 1
+            hash = hash * 31 + count.hashCode()
+            hash = hash * 31 + fill.hashCode()
+            return hash
         }
     }
 
@@ -86,8 +100,12 @@ interface SimpleGridCells {
      * column count will be 4 and each cell will have 20dp width.
      *
      * @param minSize The minimum size which each cell should have.
+     * @param fill When `true`, item composable fill cell's width or height.
      */
-    class Adaptive(private val minSize: Dp) : SimpleGridCells {
+    class Adaptive(
+        private val minSize: Dp,
+        private val fill: Boolean = true
+    ) : SimpleGridCells {
         init {
             if (minSize <= 0.dp) {
                 throw IllegalArgumentException("Adaptive minSize must be a positive value, but $minSize")
@@ -109,14 +127,22 @@ interface SimpleGridCells {
             }
         }
 
+        override fun fillCellSize(): Boolean {
+            return fill
+        }
+
         override fun equals(other: Any?): Boolean {
             if (other !is Adaptive) return false
             if (this.minSize != other.minSize) return false
+            if (this.fill != other.fill) return false
             return true
         }
 
         override fun hashCode(): Int {
-            return -minSize.hashCode()
+            var hash = -1
+            hash = hash * 31 + minSize.hashCode()
+            hash = hash * 31 + fill.hashCode()
+            return hash
         }
     }
 }

--- a/sample-android/src/main/java/com/example/compose/grid/android/MainActivity.kt
+++ b/sample-android/src/main/java/com/example/compose/grid/android/MainActivity.kt
@@ -44,6 +44,8 @@ class MainActivity : ComponentActivity() {
             var useRandomSize by remember { mutableStateOf(true) }
             var fixedCount by remember { mutableStateOf(3) }
             var adaptiveMinSize by remember { mutableStateOf(80.dp) }
+            var fixedFill by remember { mutableStateOf(true) }
+            var adaptiveFill by remember { mutableStateOf(true) }
             var cells: SimpleGridCells by remember { mutableStateOf(SimpleGridCells.Fixed(fixedCount)) }
             var layoutDirection: LayoutDirection by remember { mutableStateOf(LayoutDirection.Ltr) }
             var orientation: Orientation by remember { mutableStateOf(Orientation.Vertical) }
@@ -94,6 +96,10 @@ class MainActivity : ComponentActivity() {
                             onFixedCountChange = { fixedCount = it },
                             adaptiveMinSize = adaptiveMinSize,
                             onAdaptiveMinSizeChange = { adaptiveMinSize = it },
+                            fixedFill = fixedFill,
+                            onFixedFillChange = { fixedFill = it },
+                            adaptiveFill = adaptiveFill,
+                            onAdaptiveFillChange = { adaptiveFill = it },
                             layoutDirection = layoutDirection,
                             onLayoutDirectionChange = { layoutDirection = it },
                             orientation = orientation,

--- a/sample-android/src/main/java/com/example/compose/grid/android/OptionsSheet.kt
+++ b/sample-android/src/main/java/com/example/compose/grid/android/OptionsSheet.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -48,6 +49,10 @@ fun OptionsSheet(
     onFixedCountChange: (Int) -> Unit,
     adaptiveMinSize: Dp,
     onAdaptiveMinSizeChange: (Dp) -> Unit,
+    fixedFill: Boolean,
+    onFixedFillChange: (Boolean) -> Unit,
+    adaptiveFill: Boolean,
+    onAdaptiveFillChange: (Boolean) -> Unit,
     layoutDirection: LayoutDirection,
     onLayoutDirectionChange: (LayoutDirection) -> Unit,
     orientation: Orientation,
@@ -106,30 +111,74 @@ fun OptionsSheet(
                     state = cellsOptionsState,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    SelectableSliderOption(
+                    CellStrategyOption(
                         title = "Fixed",
                         isSelected = cells is SimpleGridCells.Fixed,
                         indicator = fixedCount.toString(),
                         value = fixedCount.toFloat(),
                         valueRange = 1f..10f,
                         steps = 10,
-                        onClick = { onCellsChange(SimpleGridCells.Fixed(fixedCount)) },
+                        onClick = {
+                            onCellsChange(
+                                SimpleGridCells.Fixed(
+                                    count = fixedCount,
+                                    fill = fixedFill
+                                )
+                            )
+                        },
                         onValueChange = {
                             onFixedCountChange(it.toInt())
-                            onCellsChange(SimpleGridCells.Fixed(it.toInt()))
+                            onCellsChange(
+                                SimpleGridCells.Fixed(
+                                    count = it.toInt(),
+                                    fill = fixedFill
+                                )
+                            )
+                        },
+                        checked = fixedFill,
+                        onCheckedChange = {
+                            onFixedFillChange(it)
+                            onCellsChange(
+                                SimpleGridCells.Fixed(
+                                    count = fixedCount,
+                                    fill = it
+                                )
+                            )
                         },
                     )
-                    SelectableSliderOption(
+                    CellStrategyOption(
                         title = "Adaptive",
                         isSelected = cells is SimpleGridCells.Adaptive,
                         indicator = adaptiveMinSize.toString(),
                         value = adaptiveMinSize.value,
                         valueRange = 50f..150f,
                         steps = 19,
-                        onClick = { onCellsChange(SimpleGridCells.Adaptive(adaptiveMinSize)) },
+                        onClick = {
+                            onCellsChange(
+                                SimpleGridCells.Adaptive(
+                                    minSize = adaptiveMinSize,
+                                    fill = adaptiveFill
+                                )
+                            )
+                        },
                         onValueChange = {
                             onAdaptiveMinSizeChange(it.dp)
-                            onCellsChange(SimpleGridCells.Adaptive(it.dp))
+                            onCellsChange(
+                                SimpleGridCells.Adaptive(
+                                    minSize = it.dp,
+                                    fill = adaptiveFill
+                                )
+                            )
+                        },
+                        checked = adaptiveFill,
+                        onCheckedChange = {
+                            onAdaptiveFillChange(it)
+                            onCellsChange(
+                                SimpleGridCells.Adaptive(
+                                    minSize = adaptiveMinSize,
+                                    fill = it
+                                )
+                            )
                         },
                     )
                 }
@@ -328,7 +377,7 @@ private fun SliderOption(
 }
 
 @Composable
-private fun SelectableSliderOption(
+private fun CellStrategyOption(
     title: String,
     isSelected: Boolean,
     indicator: String,
@@ -336,6 +385,8 @@ private fun SelectableSliderOption(
     valueRange: ClosedFloatingPointRange<Float>,
     onClick: () -> Unit,
     onValueChange: (Float) -> Unit,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     steps: Int = 0,
 ) {
@@ -351,7 +402,10 @@ private fun SelectableSliderOption(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(text = title)
+                Text(
+                    text = title,
+                    color = if (isSelected) Color.Unspecified else Color.Gray
+                )
                 if (isSelected) {
                     Icon(
                         painter = painterResource(R.drawable.round_check_24),
@@ -369,6 +423,7 @@ private fun SelectableSliderOption(
                 Text(
                     modifier = Modifier.weight(0.25f),
                     text = indicator,
+                    color = if (isSelected) Color.Unspecified else Color.Gray,
                     fontWeight = FontWeight.Normal,
                 )
                 Slider(
@@ -378,6 +433,24 @@ private fun SelectableSliderOption(
                     onValueChange = onValueChange,
                     steps = steps,
                     enabled = isSelected,
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(OptionDefaults.Height),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Fill",
+                    color = if (isSelected) Color.Unspecified else Color.Gray,
+                    fontWeight = FontWeight.Normal,
+                )
+                Switch(
+                    checked = checked,
+                    onCheckedChange = onCheckedChange,
+                    enabled = isSelected
                 )
             }
         }

--- a/sample-desktop/src/main/kotlin/com/example/compose/grid/desktop/Main.kt
+++ b/sample-desktop/src/main/kotlin/com/example/compose/grid/desktop/Main.kt
@@ -42,6 +42,8 @@ fun main() = application {
         var useRandomSize by remember { mutableStateOf(true) }
         var fixedCount by remember { mutableStateOf(3) }
         var adaptiveMinSize by remember { mutableStateOf(80.dp) }
+        var fixedFill by remember { mutableStateOf(true) }
+        var adaptiveFill by remember { mutableStateOf(true) }
         var cells: SimpleGridCells by remember { mutableStateOf(SimpleGridCells.Fixed(fixedCount)) }
         var layoutDirection: LayoutDirection by remember { mutableStateOf(LayoutDirection.Ltr) }
         var orientation: Orientation by remember { mutableStateOf(Orientation.Vertical) }
@@ -93,6 +95,10 @@ fun main() = application {
                     onFixedCountChange = { fixedCount = it },
                     adaptiveMinSize = adaptiveMinSize,
                     onAdaptiveMinSizeChange = { adaptiveMinSize = it },
+                    fixedFill = fixedFill,
+                    onFixedFillChange = { fixedFill = it },
+                    adaptiveFill = adaptiveFill,
+                    onAdaptiveFillChange = { adaptiveFill = it },
                     layoutDirection = layoutDirection,
                     onLayoutDirectionChange = { layoutDirection = it },
                     orientation = orientation,

--- a/sample-desktop/src/main/kotlin/com/example/compose/grid/desktop/OptionPane.kt
+++ b/sample-desktop/src/main/kotlin/com/example/compose/grid/desktop/OptionPane.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Divider
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
@@ -326,7 +325,6 @@ private fun SliderOption(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SelectableSliderOption(
     title: String,
@@ -384,7 +382,6 @@ private fun SelectableSliderOption(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SelectableOption(
     title: String,
@@ -415,7 +412,6 @@ private fun SelectableOption(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ToggleOption(
     title: String,
@@ -450,7 +446,6 @@ private fun ToggleOption(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ExpandableOption(
     title: String,

--- a/sample-desktop/src/main/kotlin/com/example/compose/grid/desktop/OptionPane.kt
+++ b/sample-desktop/src/main/kotlin/com/example/compose/grid/desktop/OptionPane.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -47,6 +48,10 @@ fun OptionPane(
     onFixedCountChange: (Int) -> Unit,
     adaptiveMinSize: Dp,
     onAdaptiveMinSizeChange: (Dp) -> Unit,
+    fixedFill: Boolean,
+    onFixedFillChange: (Boolean) -> Unit,
+    adaptiveFill: Boolean,
+    onAdaptiveFillChange: (Boolean) -> Unit,
     layoutDirection: LayoutDirection,
     onLayoutDirectionChange: (LayoutDirection) -> Unit,
     orientation: Orientation,
@@ -105,30 +110,74 @@ fun OptionPane(
                     state = cellsOptionsState,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    SelectableSliderOption(
+                    CellStrategyOption(
                         title = "Fixed",
                         isSelected = cells is SimpleGridCells.Fixed,
                         indicator = fixedCount.toString(),
                         value = fixedCount.toFloat(),
                         valueRange = 1f..10f,
                         steps = 10,
-                        onClick = { onCellsChange(SimpleGridCells.Fixed(fixedCount)) },
+                        onClick = {
+                            onCellsChange(
+                                SimpleGridCells.Fixed(
+                                    count = fixedCount,
+                                    fill = fixedFill
+                                )
+                            )
+                        },
                         onValueChange = {
                             onFixedCountChange(it.toInt())
-                            onCellsChange(SimpleGridCells.Fixed(it.toInt()))
+                            onCellsChange(
+                                SimpleGridCells.Fixed(
+                                    count = it.toInt(),
+                                    fill = fixedFill
+                                )
+                            )
+                        },
+                        checked = fixedFill,
+                        onCheckedChange = {
+                            onFixedFillChange(it)
+                            onCellsChange(
+                                SimpleGridCells.Fixed(
+                                    count = fixedCount,
+                                    fill = it
+                                )
+                            )
                         },
                     )
-                    SelectableSliderOption(
+                    CellStrategyOption(
                         title = "Adaptive",
                         isSelected = cells is SimpleGridCells.Adaptive,
                         indicator = adaptiveMinSize.toString(),
                         value = adaptiveMinSize.value,
                         valueRange = 50f..150f,
                         steps = 19,
-                        onClick = { onCellsChange(SimpleGridCells.Adaptive(adaptiveMinSize)) },
+                        onClick = {
+                            onCellsChange(
+                                SimpleGridCells.Adaptive(
+                                    minSize = adaptiveMinSize,
+                                    fill = adaptiveFill
+                                )
+                            )
+                        },
                         onValueChange = {
                             onAdaptiveMinSizeChange(it.dp)
-                            onCellsChange(SimpleGridCells.Adaptive(it.dp))
+                            onCellsChange(
+                                SimpleGridCells.Adaptive(
+                                    minSize = it.dp,
+                                    fill = adaptiveFill
+                                )
+                            )
+                        },
+                        checked = adaptiveFill,
+                        onCheckedChange = {
+                            onAdaptiveFillChange(it)
+                            onCellsChange(
+                                SimpleGridCells.Adaptive(
+                                    minSize = adaptiveMinSize,
+                                    fill = it
+                                )
+                            )
                         },
                     )
                 }
@@ -326,7 +375,7 @@ private fun SliderOption(
 }
 
 @Composable
-private fun SelectableSliderOption(
+private fun CellStrategyOption(
     title: String,
     isSelected: Boolean,
     indicator: String,
@@ -334,6 +383,8 @@ private fun SelectableSliderOption(
     valueRange: ClosedFloatingPointRange<Float>,
     onClick: () -> Unit,
     onValueChange: (Float) -> Unit,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     steps: Int = 0,
 ) {
@@ -349,7 +400,10 @@ private fun SelectableSliderOption(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(text = title)
+                Text(
+                    text = title,
+                    color = if (isSelected) Color.Unspecified else Color.Gray
+                )
                 if (isSelected) {
                     Icon(
                         painter = painterResource("check_black_24dp.svg"),
@@ -367,6 +421,7 @@ private fun SelectableSliderOption(
                 Text(
                     modifier = Modifier.weight(0.25f),
                     text = indicator,
+                    color = if (isSelected) Color.Unspecified else Color.Gray,
                     fontWeight = FontWeight.Normal,
                 )
                 Slider(
@@ -376,6 +431,24 @@ private fun SelectableSliderOption(
                     onValueChange = onValueChange,
                     steps = steps,
                     enabled = isSelected,
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(OptionDefaults.Height),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Fill",
+                    color = if (isSelected) Color.Unspecified else Color.Gray,
+                    fontWeight = FontWeight.Normal,
+                )
+                Switch(
+                    checked = checked,
+                    onCheckedChange = onCheckedChange,
+                    enabled = isSelected
                 )
             }
         }


### PR DESCRIPTION
Add `fill` param to `SimpleGridCell.Fixed` and `SimpleGridCell.Adaptive`.
When `fill` is enabled, item composable in each cells should fill cell's width or height. When disabled, item composable can have free size within the cell's width or height.