### PR TITLE
Fix unexpected crash caused when measuring invisible item constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed incorrect layout size when grid should have smaller size than constraints max size.
 - Fixed incorrect spacing before the last item.
+- Fixed crash when measuring invisible item composable constraints.
 
 ## 1.2.0
 

--- a/grid/src/commonMain/kotlin/io/woong/compose/grid/MeasureHelper.kt
+++ b/grid/src/commonMain/kotlin/io/woong/compose/grid/MeasureHelper.kt
@@ -148,7 +148,7 @@ internal class GridMeasureHelper(
                         mainAxisMaxSize = if (mainAxisMaxLayoutSize == Constraints.Infinity) {
                             Constraints.Infinity
                         } else {
-                            mainAxisMaxLayoutSize - mainAxisPlacedSpace
+                            (mainAxisMaxLayoutSize - mainAxisPlacedSpace).coerceAtLeast(0)
                         },
                         crossAxisMinSize = if (fillCellSize) crossAxisCellConstraints else 0,
                         crossAxisMaxSize = crossAxisCellConstraints,


### PR DESCRIPTION
When measuring invisible item's constraints, there is possibility of crash. Because constraint mainAxisMaxSize could be minus while calculating.
This fix add `coerceAtLeast(0)` to prevent minus value.